### PR TITLE
修复：切换日期时未保存内容可能丢失

### DIFF
--- a/main.py
+++ b/main.py
@@ -1150,27 +1150,33 @@ class DiaryApp(QMainWindow):
         new_date = self.calendar.selectedDate()
         if new_date != self.current_date:
             print(f"日期变更: {self.current_date.toString('yyyy-MM-dd')} -> {new_date.toString('yyyy-MM-dd')}")
-            
-            # 1. 保存当前日期的日记
-            save_result = self.save_entry_for_date(self.current_date)
-            if not save_result:
-                # 保存失败，询问用户是否仍要切换日期
+
+            if self.content_modified:
                 reply = QMessageBox.question(
-                    self, 
-                    "保存失败", 
-                    f"保存 {self.current_date.toString('yyyy-MM-dd')} 的日记失败。\n是否仍要切换到新日期？",
-                    QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-                    QMessageBox.StandardButton.No
+                    self,
+                    "未保存内容",
+                    "当前日记尚未保存，是否先保存再切换日期？",
+                    QMessageBox.StandardButton.Save
+                    | QMessageBox.StandardButton.Discard
+                    | QMessageBox.StandardButton.Cancel,
+                    QMessageBox.StandardButton.Save,
                 )
-                
-                if reply == QMessageBox.StandardButton.No:
-                    # 用户选择不切换，恢复日历选择
-                    self.calendar.blockSignals(True)  # 阻止信号触发新的事件
+
+                if reply == QMessageBox.StandardButton.Cancel:
+                    self.calendar.blockSignals(True)
                     self.calendar.setSelectedDate(self.current_date)
-                    self.calendar.blockSignals(False)  # 恢复信号处理
-                    # 恢复后刷新一次日历格式，避免“选中高亮”残留在新日期上
+                    self.calendar.blockSignals(False)
                     self.update_calendar_highlighting()
                     return
+
+                if reply == QMessageBox.StandardButton.Save:
+                    save_result = self.save_entry_for_date(self.current_date)
+                    if not save_result:
+                        self.calendar.blockSignals(True)
+                        self.calendar.setSelectedDate(self.current_date)
+                        self.calendar.blockSignals(False)
+                        self.update_calendar_highlighting()
+                        return
 
             # 2. 更新当前日期
             self.current_date = new_date


### PR DESCRIPTION
### Motivation
- 修复在日历切换日期时，如果当前编辑内容未保存会被覆盖或丢失的问题。

### Description
- 在 `main.py` 的 `handle_date_change` 中改为先检测 `self.content_modified` 并在有未保存内容时弹出带 `Save`/`Discard`/`Cancel` 的 `QMessageBox`。 
- 当用户选择 `Save` 时调用 `save_entry_for_date(self.current_date)`，若保存失败则恢复原选中日期并中止切换。 
- 当用户选择 `Cancel` 时恢复日历选中状态并中止切换以避免内容被覆盖。 
- 切换/恢复过程中使用 `calendar.blockSignals(True/False)` 与 `update_calendar_highlighting()` 防止视觉残留或重复信号触发。

### Testing
- 自动化测试：未运行任何自动化测试（无现有自动化测试套件）。
- 手动验证步骤：启动应用后在某日期编辑但不保存，尝试切换到另一日期并验证弹出对话框、选择 `Save` 会进行保存并切换、选择 `Discard` 会直接切换、选择 `Cancel` 会保持原日期且内容不丢失，手动验证通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989db3f7184832db8369144ecf12ecb)